### PR TITLE
Fix typo - ${routeName} is not working and you need to use ${route}

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -28,7 +28,7 @@ This topic describes how to install and configure the Apigee Edge Service Broker
 	**Apigee Management API URL** | The endpoint URL to the Apigee Edge management API. The Apigee Edge Service Broker uses this URL when making requests to create new Apigee Edge API proxies for managing requests to PCF apps. | `https://api.enterprise.apigee.com/v1`
 	**Apigee Proxy Domain** | The domain name that PCF apps use when making calls to your API proxy. | `apigee.net`
 	**Apigee Proxy Host Template** | The template that describes how the Apigee Edge host name should be generated. PCF apps use this host when making calls to your API proxy. The template generates the host name from values specified when binding the PCF app to the service instance of the Apigee Edge service. Typically, `org` and `env` represent your Apigee Edge organization and environment names, and `domain` represents the proxy domain you specify above. Parts of this value not formatted as placeholders will be taken to be literal.| `${org}-${env}.${domain}`
-	**Apigee Proxy Name Template** | The template that describes how to generate the name of your proxy when you create it from the cf CLI. | `cf-${routeName}`
+	**Apigee Proxy Name Template** | The template that describes how to generate the name of your proxy when you create it from the cf CLI. | `cf-${route}`
 
 1. Click **Save**.
 1. Return to the Ops Manager Installation Dashboard and click **Apply Changes** to install the Apigee Edge Service Broker for PCF tile.


### PR DESCRIPTION
Fix typo. 
```${routeName}``` is not working and you need to use ```${route}``` instead. 

See the proper documentation here: 
https://github.com/apigee/pivotal-cf-apigee/tree/master/apigee-cf-service-broker

The official Apigee documentation should be fixed as well:
http://docs.apigee.com/api-services/content/install-and-configure-apigee-service-broker
