### PR TITLE
Updates for release 3.1.1

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -45,23 +45,23 @@ The following table provides version and version-support information about Apige
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v3.1.0</td>
+        <td>v3.1.1</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>June 28, 2018</td>
+        <td>September 24, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>Apigee Edge Service Broker for PCF v3.1.0</td>
+        <td>Apigee Edge Service Broker for PCF v3.1.1</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.7.x to v2.1.x</td>
+        <td>v2.1.x to v2.2.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>v1.7.x to 2.1.x</td>
+        <td>v2.1.x to 2.2.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -91,8 +91,8 @@ The Apigee Edge Service Broker for PCF has the following prerequisites:
 
 * An Apigee Edge account (Public Cloud or Private Cloud) with an organization where API proxies can be created. To create an Edge account, see [Creating an Apigee Edge account](http://docs.apigee.com/api-services/content/creating-apigee-edge-account). For more information about Apigee organizations, see [Organization structure](http://docs.apigee.com/api-services/content/apigee-edge-organization-structure).
 * Apigee Edge Microgateway, depending on the service plan you're using.
-* A PCF Elastic Runtime (version 1.7 to 1.12) deployment with Route Services enabled.
-* A PAS Pivotal Application Services deployment for PCF version 2.0.0 or greater with Route Services enabled.
+* A PCF Elastic Runtime (version 2.1 to 2.2) deployment with Route Services enabled.
+* A PAS Pivotal Application Services deployment for PCF version 2.1.0 or greater with Route Services enabled.
 * The [cf CLI](https://github.com/cloudfoundry/cli) v6.20.0+, which includes  support for `route-services` operations.
 * Node.js v4.x or later. PCF includes Node.js as a system buildpack, so you can install and run the service broker without Node installed locally, if necessary.
 

--- a/proxying-microgateway-coresident.html.md.erb
+++ b/proxying-microgateway-coresident.html.md.erb
@@ -11,31 +11,31 @@ In the process described here, the PCF app and Microgateway are in the same Clou
 
 Before performing the procedures in this topic, you must [install and configure](installing.html) the Apigee Edge Service Broker for PCF tile.
 
-Steps in these instructions use CF CLI with an Apigee plugin. To see corresponding CF CLI commands, see [Mapping for Apigee and Cloud Foundry integration commands](https://github.com/apigee/cloud-foundry-apigee/tree/master/docs/mapping-apigee-cf-cli.md).
-
 ## <a id="create-instance"></a>Step 1: Create a Service Instance
 
 Perform the following steps to create an instance of the Apigee Edge service:
 
 1. List the Marketplace services and locate the Apigee Edge service:
 
-    <pre class="terminal">
+    ```bash
     $ cf marketplace
     Getting services from marketplace in org example / space development as user<span>@</span>example.com...
     OK
 
     service          plans                     description
     apigee-edge      org, microgateway, microgateway-coresident         Apigee Edge API Platform
-    </pre>
+    ```
 
 1. Create an instance of the Apigee Edge service. Select the `microgateway-coresident` service plan to have Apigee Edge Microgateway run in the same container as your Cloud Foundry app.
 
-    <pre class="terminal">$ cf create-service apigee-edge microgateway-coresident YOUR-SERVICE-INSTANCE -c \
-    '{"org":"YOUR-ORG", "env":"YOUR-ENV"}'</pre>
+    ```bash
+    $ cf create-service apigee-edge microgateway-coresident YOUR-SERVICE-INSTANCE -c \
+    '{"org":"YOUR-ORG", "env":"YOUR-ENV"}'
+    ```
 
 1. Use the `cf service` command to display information about the service instance:
 
-    <pre class="terminal">
+    ```bash
     $ cf service YOUR-SERVICE-INSTANCE
 
     Service instance: YOUR-SERVICE-INSTANCE
@@ -52,50 +52,19 @@ Perform the following steps to create an instance of the Apigee Edge service:
     Message:
     Started: 2016-10-27T20:47:43Z
     Updated:
-    </pre>
+    ```
 
-## <a name="instance"></a>Step 2: Install the Plugin
-
-1. Install the Apigee Broker Plugin as follows.
-    <pre class="terminal">
-    $ cf install-plugin -r CF-Community "apigee-broker-plugin"                                                                                                                                 
-    Searching CF-Community for plugin apigee-broker-plugin...
-    Plugin apigee-broker-plugin 0.1.1 found in: CF-Community
-    Attention: Plugins are binaries written by potentially untrusted authors.
-    Install and use plugins at your own risk.
-    Do you want to install the plugin apigee-broker-plugin? [yN]: y
-    Starting download of plugin binary from repository CF-Community...
-    7.85 MiB / 7.85 MiB [===========================================================================================================================================================================================================================================] 100.00% 11s
-    Installing plugin Apigee-Broker-Plugin...
-    OK
-    Plugin Apigee-Broker-Plugin 0.1.1 successfully installed.
-    </pre>
-
-1. Make sure the plugin is available by running the following command:
-
-    <pre class="terminal">
-    $ cf -h
-    …
-    Commands offered by installed plugins:
-      apigee-bind-mg,abm      apigee-unbind-mgc,auc    enable-diego
-      apigee-bind-mgc,abc     apigee-unbind-org,auo    has-diego-enabled
-      apigee-bind-org,abo     dea-apps                 migrate-apps
-      apigee-push,ap          diego-apps               dev,pcfdev
-      apigee-unbind-mg,aum    disable-diego
-    </pre>
-
-## <a name="install-microgateway"></a>Step 3: Install Apigee Edge Microgateway and Cloud Foundry App
+## <a name="install-microgateway"></a>Step 2: Install Apigee Edge Microgateway and Cloud Foundry App
 Here, you install Apigee Edge Microgateway and your Cloud Foundry app to the same Cloud Foundry container.
 
 1. [Install and configure Apigee Edge Microgateway.](http://docs.apigee.com/microgateway/latest/installing-edge-microgateway)
 
 1. Locate and make any desired changes to the configuration YAML file created in your Apigee Edge Microgateway installation, typically in the `.edgemicro` directory.
 
-1. Copy the configuration file to the following directory in your Cloud Foundry app: `<application-folder>/<config-directory>`.
-
 1. Complete plugin configuration in one of two ways:
+
     - Configure the plugins via the app manifest to include the APIGEE_MICROGATEWAY_CUSTOM environment variable. For example:
-	
+
         ```yaml
           env:
           ...
@@ -103,28 +72,26 @@ Here, you install Apigee Edge Microgateway and your Cloud Foundry app to the sam
           APIGEE_MICROGATEWAY_CUST_PLUGINS: plugins
           APIGEE_MICROGATEWAY_PROCESSES: 2
           APIGEE_MICROGATEWAY_CUSTOM: |
-                                      {"policies":
-                                      {
-                                      "oauth":
-                                          {
-                                          "allowNoAuthorization": false, 
-                                          "allowInvalidAuthorization": false
+                                      { 
+                                        "policies": {
+                                           "oauth": {
+                                              "allowNoAuthorization": false, 
+                                              "allowInvalidAuthorization": false
+                                            },
+                                            "spikearrest": {
+                                              "timeUnit": "minute", 
+                                              "allow": 10
+                                            }
                                           },
-                                      "spikearrest": 
-                                          {
-                                          "timeUnit": "minute", 
-                                          "allow": 10
-                                          }
-                                      },
-                                      "sequence": ["oauth", "spikearrest"]
+                                        "sequence": ["oauth", "spikearrest"]
                                       }
         ```
         To support Cloud Foundry application health checks, make sure your `applications` block includes the `health-check-type` and `health-check-http-endpoint` properties:
-        
+
         ```yaml
         health-check-type: http
         health-check-http-endpoint: /healthcheck
-        ```        
+        ```
 
         The `sequence` property must also include a reference to the `healthcheck` plugin, as shown here:
 
@@ -133,7 +100,7 @@ Here, you install Apigee Edge Microgateway and your Cloud Foundry app to the sam
         ```
 
         For more on health checks, see [Using Application Health Checks](https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html).
- 
+
         The following describes the manifest properties:
 
         Variable | Description
@@ -142,7 +109,13 @@ Here, you install Apigee Edge Microgateway and your Cloud Foundry app to the sam
         `APIGEE_MICROGATEWAY_CUST_PLUGINS` | Location of your Apigee Microgateway plugins directory.
         `APIGEE_MICROGATEWAY_PROCESSES` | The number of child processes that Apigee Microgateway should start. If your Microgateway performance is poor, setting this value higher might improve it.
         `APIGEE_MICROGATEWAY_CUSTOM` | “sequence” corresponds to the sequence order in the microgateway yaml file (this will be added on to the end of any current sequence in the microgateway yaml file with duplicates removed).<br/><br/>“policies” correspond to any specific configuration needed by a plugin; for instance, “oauth” has the ‘"allowNoAuthorization": true configuration. These policies will overwrite any existing policies in the microgateway yaml file and add any that do not yet exist.
-    - Configure the microgateway yaml file from step 2 to include the necessary plugins. For example if we added a “spikearrest” plugin:
+        `APIGEE_MICROGATEWAY_NODEJS_FILENAME` | Name of a Node.js .tar file in the `lib/` directory, which is located in the `microgateway_decorator` buildpack.  In this case, the local install will be used to run the Microgateway instead of downloading Node.js.
+        `APIGEE_MICROGATEWAY_NODEJS_URL` | A custom URL from which to download the Node.js used to run Microgateway.
+        `APIGEE_MICROGATEWAY_NODEJS_VERSION` | The version of Node.js used to run Microgateway. This is downloaded from https://nodejs.org.
+        `APIGEE_MICROGATEWAY_VERSION` | The version of Microgateway to use.
+
+    - Configure the Microgateway YAML file to include the necessary plugins. For example if we added a `spikearrest` plugin:
+
         ```yaml
         ...
         plugins:
@@ -158,143 +131,214 @@ Here, you install Apigee Edge Microgateway and your Cloud Foundry app to the sam
           allowInvalidAuthorization: false
         ```
 1. Copy any custom plugins’ root folders (with custom plugin specific package.json and index.js in the respective root folder) into the following directory in your Cloud Foundry app: `<application-folder>/<plugin-directory>`. 
-    1. Remove the following or any other ``buildpack`` tags from the manifest:  
+    1. Remove the following or any other ``buildpack`` tags from the manifest:
+
         ```yaml
         buildpack: nodejs_buildpack
         ```
     1. If you have custom buildpacks, add the following line to the “env” section:
-	
+
         ```yaml
         env:
           ...
           APIGEE_MICROGATEWAY_CUST_PLUGINS: '<plugin-directory>'
         ```
 
+1. To use a custom Node.js version to run Microgateway, configure the decorator in one of the following ways:
+
+    Note: This feature is only available for version >= 3.1.* of the `microgateway_decorator`
+
+    * To use a Node.js tar.gz from a location accessible via http or https other than https://nodejs.org:
+
+      ```yaml
+      env:
+          # APIGEE_MICROGATEWAY_PROXY: edgemicro_cf-test.local.pcfdev.io
+          APIGEE_MICROGATEWAY_CONFIG_DIR: config
+          APIGEE_MICROGATEWAY_NODEJS_URL: https://mycustomdomain.com/mynoderoot/versions/node-v8.11.3-linux-x64.tar.gz
+          # APIGEE_MICROGATEWAY_PROCESSES: 2
+          # APIGEE_MICROGATEWAY_CUSTOM: | {...} --> uncomment if applicable
+      ```
+    * To select a specific Node.js version from https://nodejs.org:
+
+      ```yaml
+      env:
+          # APIGEE_MICROGATEWAY_PROXY: edgemicro_cf-test.local.pcfdev.io
+          APIGEE_MICROGATEWAY_CONFIG_DIR: config
+          APIGEE_MICROGATEWAY_NODEJS_VERSION: 8.11.3
+          # APIGEE_MICROGATEWAY_PROCESSES: 2
+          # APIGEE_MICROGATEWAY_CUSTOM: | {...} --> uncomment if applicable
+      ```
+    * To use the default Node.js version of 8.11.3 from https://nodejs.org:
+
+      ```yaml
+      env:
+          # APIGEE_MICROGATEWAY_PROXY: edgemicro_cf-test.local.pcfdev.io
+          APIGEE_MICROGATEWAY_CONFIG_DIR: config
+          # APIGEE_MICROGATEWAY_PROCESSES: 2
+          # APIGEE_MICROGATEWAY_CUSTOM: | {...} --> uncomment if applicable
+      ```
+    * To use a specific version of Node.js used from the decorator, then include the Node.js .tar file in the `lib/` directory which is located in the `microgateway_decorator` buildpack. In this case, the local install will be used to run Microgateway instead of downloading Nodejs.
+
+      ```yaml
+      env:
+          # APIGEE_MICROGATEWAY_PROXY: edgemicro_cf-test.local.pcfdev.io
+          APIGEE_MICROGATEWAY_CONFIG_DIR: config
+          APIGEE_MICROGATEWAY_NODEJS_FILENAME: node-v6.11.3-linux-x64.tar.gz
+          # APIGEE_MICROGATEWAY_PROCESSES: 2
+          # APIGEE_MICROGATEWAY_CUSTOM: | {...} --> uncomment if applicable
+      ```
+1. To use a custom Microgateway version, configure the decorator in one of the following ways. If you don't include `APIGEE_MICROGATEWAY_VERSION`, then it will use version 2.5.8 in the GitHub repository.
+
+    Note: This feature is only available for version >= 3.1.* of the `microgateway_decorator`.
+
+    * To use a specific version of Edge Microgateway, include this environment variable. This will execute a `git clone` on the https://github.com/apigee-internal/microgateway repository.
+
+      ```yaml
+      env:
+          # APIGEE_MICROGATEWAY_PROXY: edgemicro_cf-test.local.pcfdev.io
+          APIGEE_MICROGATEWAY_VERSION: 2.5.19
+          APIGEE_MICROGATEWAY_CONFIG_DIR: config
+          # APIGEE_MICROGATEWAY_NODEJS_LOCAL_INSTALL: false
+          # APIGEE_MICROGATEWAY_PROCESSES: 2
+          # APIGEE_MICROGATEWAY_CUSTOM: | {...} --> uncomment if applicable
+      ```
+    * To use specific version of Edge Microgateway installed from the decorator, then clone the repository into the `lib/` directory which is located in the `microgateway_decorator` buildpack.  In this case, the decorator will use the locally cloned repository instead of cloning from github.com.
+
+      ```yaml
+      env:
+          # APIGEE_MICROGATEWAY_PROXY: edgemicro_cf-test.local.pcfdev.io
+          APIGEE_MICROGATEWAY_VERSION: 2.5.19
+          APIGEE_MICROGATEWAY_CONFIG_DIR: config
+          # APIGEE_MICROGATEWAY_NODEJS_LOCAL_INSTALL: false
+          # APIGEE_MICROGATEWAY_PROCESSES: 2
+          # APIGEE_MICROGATEWAY_CUSTOM: | {...} --> uncomment if applicable
+      ```
+
 1. Ensure that your Cloud Foundry app isn't running on port 8080, nor on the port specified by the PORT environment variable.
 
 1. Push the Cloud Foundry app to your Cloud Foundry container.
-    <pre class="terminal">cf apigee-push</pre>
-    
-    You'll be prompted for the following:
 
-    Argument | Description
-    --- | ---
-    Plan type confirmation | Specify whether you're using the microgateway-coresident plan.
-    Path to your Java archive | If your app is a Java app, specify the path to its .jar file.
-    Path to the configuration directory with Microgateway .yaml file | Location of your Apigee Microgateway configuration directory.
-    Path to the configuration directory with custom plugins | Location of your Apigee Microgateway plugins directory.
+    ```bash
+    $ cf push <cf-app-name> --no-start
+    ```
 
-## <a id="bind-app-route"></a>Step 4: Bind the Cloud Foundry App to the Service Instance
+## <a id="bind-app-route"></a>Step 3: Bind the Cloud Foundry App to the Service Instance
 
-In this step, you bind a Cloud Foundry app to the Apigee service instance you 
-created. The `apigee-bind-mgc` command creates the proxy for you and binds the app to the service.   
+In this step, you bind a Cloud Foundry app to the Apigee service instance you created. The `bind-service` command creates the proxy for you and binds the app to the service. By using `bind-service`, certain information (such as edgemicro key and secret and chosen plan ID) will be shared with the target application. In addition, since `bind-route-service` is not being used, traffic won’t be routed anywhere but the target application container.
 
-Each bind attempt requires authorization with Apigee Edge, with credentials 
-passed as additional parameters to the `apigee-bind-mgc` command. You can pass 
-these credentials as arguments of the `apigee-bind-mgc` command or by using a 
-bearer token.
+Each bind attempt requires authorization with Apigee Edge, Apigee passed as additional parameters to the `cf bind` command.
 
-1. If you're using a bearer token to authenticate with Apigee Edge, get or 
-   update the token using the Apigee SSO CLI script. (If you're instead using 
-   command-line arguments to authenticate with username and password, specify 
-   the credentials in the next step.)
+1. If you're using a bearer token to authenticate with Apigee Edge, get or update the token using the Apigee SSO CLI script. (If you're instead using command-line arguments to authenticate with username and password, specify the credentials in the next step.)
     1. Download the Apigee Edge scripts:
 
-	    <pre class="terminal">$ curl <span>https:</span>//login.apigee.com/resources/scripts/sso-cli/ssocli-bundle.zip -o "ssocli-bundle.zip"</pre>
+      ```bash
+      $ curl <span>https:</span>//login.apigee.com/resources/scripts/sso-cli/ssocli-bundle.zip -o "ssocli-bundle.zip"
+      ```
 
-	1. Unzip the `ssocli-bundle.zip` file. This includes `get_token`, a script that gets or updates a token that you use to authenticate with your Apigee Edge organization. You need this token to bind the Apigee Edge route service to your app.
+    1. Unzip the `ssocli-bundle.zip` file. This includes `get_token`, a script that gets or updates a token that you use to authenticate with your Apigee Edge organization. You need this token to bind the Apigee Edge route service to your app.
 
-	    <pre class="terminal">$ tar xvf ssocli-bundle.zip</pre>
+      ```bash
+      $ tar xvf ssocli-bundle.zip
+      ```
 
-	1. Create a `.sso-cli` directory in your user directory:
+    1. Create a `.sso-cli` directory in your user directory:
 
-	    <pre class="terminal">$ mkdir ~/.sso-cli</pre>
-	1. Use the `get_token` script to create a token. When prompted, enter the Apigee Edge username and password you use to log in to your organization.
+      ```bash
+      $ mkdir ~/.sso-cli
+      ```
 
-		<pre class="terminal">$ ./get\_token</pre>
-				
-		The `get_token` script writes the token file into `~/.sso-cli`. For more about `get_token`, see the [Apigee documentation](http://docs.apigee.com/api-services/content/using-oauth2-security-apigee-edge-management-api).
+    1. Use the `get_token` script to create a token. When prompted, enter the Apigee Edge username and password you use to log in to your organization.
 
-1. Bind the app to the Apigee service instance with the `apigee-bind-mgc` command.
+      ```bash
+      $ ./get\_token
+      ```
 
-    > Use the command without arguments to be prompted for argument values. To use  the command with arguments, see the command reference at the end of this  topic. For help on the command, type `cf apigee-bind-mgc -h`. 
-	
-	```
-	cf apigee-bind-mgc
-	```
+    The `get_token` script writes the token file into `~/.sso-cli`. For more about `get_token`, see the [Apigee documentation](http://docs.apigee.com/api-services/content/using-oauth2-security-apigee-edge-management-api).
 
-    > You'll be prompted for the following:
-	
-    Argument  | Description
-	--- | ---
-	Apigee username | Apigee user name. Not used if you pass a bearer token with the --bearer argument.
-    Apigee password | Apigee password. Not used if you pass a bearer token with the --bearer argument.
-	Action to take | Required.  proxy to generate an API proxy; bind to bind the service with the proxy; proxy bind to generate the proxy and bind with a single command.
-	Apigee environment | Required. The Apigee environment where your proxy should be deployed.
-	Apigee organization | Required. The Apigee organization where your proxy should be created.
-	Application to bind to | Required. Name of the the Cloud Foundry application to bind to.
-	Microgateway key | Required. Your Apigee Edge Microgateway key.
-	Microgateway secret | Required. Your Apigee Edge Microgateway secret.
-	Service instance name to bind to | Required. Name of the Apigee service to bind to.
-	Target application port | Required. Port for your Cloud Foundry app. This may not be 8080 nor the PORT environment variable.
-	Target application route | Required. The URL for your Cloud Foundry app. This will be the suffix of the proxy created for you through the bind command
-	
-	> The command creates an API proxy on the specified Apigee org and environment, then binds the Apigee service to the target app. To do its work, this command authenticates with Apigee Edge using the credentials you specified. You'll be prompted to start the app. If you don't and want to start it later you can start the Cloud Foundry app and microgateway-decorator along with it.
-	
-    <pre class="terminal">$ cf start APP-NAME</pre>
-    
+1. Bind the app to the Apigee service instance.
+
+    Use the [`bind-service`](http://cli.cloudfoundry.org/en-US/cf/bind-service.html) command with [JSON](#bind-service-reference) that specifies parameters.
+
+    The following example does two things: it creates an API proxy on the specified org and environment, then binds the Apigee service to the target app. The protocol parameter specifies the protocol through which the proxy's target endpoint will be called. This command authenticates with Apigee Edge using the token in the specified .dat file:
+
+    ```bash
+    $ cf bind-service <cf-app-name> <service name> \
+    -c '{"org":<microgateway-org>,"env":<microgateway-env>,
+      "bearer":"'$(cat ~/.sso-cli/valid_token.dat)'",
+      "action":"proxy bind",
+      "protocol":"http",
+      "edgemicro_key":<microgateway-config-key>,
+      "edgemicro_secret":<microgateway-config-secret>,
+      "target_app_port":<cf-app-port>}'
+    ```
+
+1. Start the Cloud Foundry app and microgateway-decorator along with it.
+
+    ```bash
+    $ cf v3-push <cf-app-name> -b microgateway_decorator -b <language buildpack (e.g nodejs_builpdack)>
+    ```
+
+   * If you are using the v3.0.0 decorator with Java, run:
+
+      ```bash
+      $ cf start APP-NAME
+      ```
+
 1. Log into Edge and note that the proxy has been created. Then follow [the instructions](http://docs.apigee.com/microgateway/latest/setting-and-configuring-edge-microgateway#Part2) to create a product with your newly created proxy. You can now configure standard Apigee Edge policies on that proxy.
 
-### apigee-bind-mgc Reference
-Use the `apigee-bind-mgc` command to generate an API proxy on Apigee Edge and to bind the Cloud Foundry service to the proxy.
+## <a id="test-binding"></a>Step 4: Test the Binding
 
-The command requires your Apigee Edge credentials in order to create and bind to an API proxy. You can specify credentials either with a bearer token or by 
-giving a username and password at the command line. To use a token, you must 
-provide the `--bearer` argument.
+Once you’ve bound your app’s path to the Apigee service (creating an Apigee proxy in the process), you can try it out with the sample app.
 
-To be prompted for argument values (and provide a username and password at 
-prompts), use the command without arguments.  
+- From a command line run the curl command you ran earlier to make a request to your Cloud Foundry app you pushed, such as:
 
-<pre class="terminal">cf apigee-bind-mgc</pre>
+    ```bash
+    $ curl https://sample-api-apigee.cfapps.pivotal.io 
+        {“hello”:“hello from cf app”}
+    ```
 
-To specify arguments on the command line, use the following syntax (be sure to 
-use quotes and command expansion, as shown here):
+    The console outputs the app’s response.
 
-<pre class="terminal">$ cf apigee-bind-mgc [--app APP_NAME] [--service SERVICE_INSTANCE] \
-    [--apigee_org APIGEE_ORGANIZATION] [--apigee_env APIGEE\_ENVIRONMENT] \ 
-    [--edgemicro_key EDGEMICRO_KEY] [--edgemicro_secret EDGEMICRO_SECRET] \
-    [--target_app_route TARGET_APP_ROUTE] [--target_app_port TARGET_APP_PORT] \ 
-    [--action ACTION] [--user APIGEE_USERNAME] [--pass APIGEE_PASSWORD] \
-    [--bearer APIGEE_BEARER_TOKEN]
-</pre>
+The new proxy is just a pass-through, but it is now ready for you or someone on your team to add policies to define security, traffic management, and more.
+
+### bind-service reference
+Use the `bind-service` command to generate an API proxy on Apigee Edge and to bind the Cloud Foundry service to the proxy. The command takes the following form (be sure to use quotes and command expansion, as shown here):
+
+```bash
+$ cf bind-service <cf-app-name> <service name> \
+    -c '{"org":<microgateway-org>,"env":<microgateway-env>,
+      "bearer":"'$(cat ~/.sso-cli/valid_token.dat)'",
+      "action":"proxy bind",
+      "protocol":"http",
+      "edgemicro_key":<microgateway-config-key>,
+      "edgemicro_secret":<microgateway-config-secret>,
+      "target_app_port":<cf-app-port>}'
+```
 
 Parameters for the `-c` argument specify connection details:
 
 Parameter | Purpose | Allowed Values
 ---- | ---- | ----
 `action` | A value specifying whether to create or bind an API proxy | `proxy` to generate an API proxy; `bind` to bind the service with the proxy; `proxy bind` to generate the proxy and bind with a single command.
-`apigee_env` | Apigee Edge environment to which the API proxy is (or will be) deployed | Your environment.
-`apigee_org` | Apigee Edge organization hosting the API proxy to be called | Your organization (must be reachable via the authentication token specified in the bearer parameter).
-`app` | Name of the the Cloud Foundry application to bind to. | The app name.
 `bearer` | Path to a file containing an authentication token valid for your organization | An authentication token, such as one generated with Apigee's get_token command. The broker does not store any data; it requires credentials and other parameters for each individual `cf` command. Instead of a `bearer` token, credentials can also be expressed as:<ul><li>`basic`: standard HTTP Base-64 encoded username and password for `Authorization: Basic`. Note that this is *not encrypted* and easily converted to clear text. But a jumble of digits and letters may provide some protection in case of momentary exposure (but no better than if the password is already a jumble of digits, letters, and symbols)</li><li>username and password in clear text</li></ul>
 `edgemicro_key` | The key for your Apigee Edge Microgateway configuration (returned when you configured the Apigee Microgateway). | The configuration key.
 `edgemicro_secret` | The secret for your Apigee Edge Microgateway configuration (returned when you configured the Apigee Microgateway). | The configuration secret.
-`pass` | Apigee password. Not used if you pass a bearer token with the --bearer argument. | Your password.
-`service` | Name of the Apigee service to bind to. | The service name.
+`env` | Apigee Edge environment to which the API proxy is (or will be) deployed | Your environment.
+`org` | Apigee Edge organization hosting the API proxy to be called | Your organization (must be reachable via the authentication token specified in he `bearer` parameter).
+`protocol` | The protocol through which the proxy's target endpoint should be accessed by Cloud Foundry. | `http` or `https`; default is `https`.
 `target_app_port` | Port for your Cloud Foundry app. This may not be 8080 nor the PORT environment variable. | The port number.
-`target_app_route` | The URL for your Cloud Foundry app. | The app URL.
-`user` | Apigee user name. Not used if you pass a bearer token with the --bearer argument. | Your user name.
 
-## <a id="test-binding"></a>Step 5: Test the Binding
+## Unbinding the service
 
-Once you’ve bound your app’s path to the Apigee service (creating an Apigee proxy in the process), you can try it out with the sample app.
+The `unbind-service` command accepts two parameters.
 
-- From a command line run the curl command you ran earlier to make a request to your Cloud Foundry app you pushed, such as:
+```bash
+$ cf unbind-service <cf-app-name> <service name>
+```
 
-    <pre class="terminal">
-    $ curl https://sample-api-apigee.cfapps.pivotal.io 
-        {“hello”:“hello from cf app”}</pre>
+## Uninstalling the service instance and broker
 
-    The console outputs the app’s response.
-
-The new proxy is just a pass-through, but it is now ready for you or someone on your team to add policies to define security, traffic management, and more.
+```bash
+$ cf delete-service <service name>
+$ cf delete-service-broker apigee-edge
+```

--- a/proxying-microgateway.html.md.erb
+++ b/proxying-microgateway.html.md.erb
@@ -5,36 +5,33 @@ owner: Partners
 
 <strong><%= modified_date %></strong>
 
-This topic describes how to push a sample app to Pivotal Cloud Foundry (PCF),
-create an Apigee Edge service instance using Apigee Edge Microgateway,
-and bind the application to it.
-After binding the application to the Apigee Edge service instance, requests to the app will be forwarded to an Apigee Edge API proxy for management.
+This topic describes how to push a sample app to Pivotal Cloud Foundry (PCF), create an Apigee Edge service instance using Apigee Edge Microgateway, and bind the application to it. After binding the application to the Apigee Edge service instance, requests to the app will be forwarded to an Apigee Edge API proxy for management.
 
-In the process described here, the PCF app and Microgateway are in separate Cloud Foundry containers.
-For a process that has them in the same container,
-see [Proxying a PCF App with Apigee Edge Microgateway ("microgateway-coresident" plan)](proxying-microgateway-coresident.html).
+In the process described here, the PCF app and Microgateway are in separate Cloud Foundry containers. For a process that has them in the same container, see [Proxying a PCF App with Apigee Edge Microgateway ("microgateway-coresident" plan)](proxying-microgateway-coresident.html).
 
 Before performing the procedures in this topic, you must [install and configure](installing.html) the Apigee Edge Service Broker for PCF tile.
-
-Steps in these instructions use CF CLI with an Apigee plugin.
-To see corresponding CF CLI commands,
-see [Mapping for Apigee and Cloud Foundry integration commands](https://github.com/apigee/cloud-foundry-apigee/tree/master/docs/mapping-apigee-cf-cli.md).
 
 ## <a id="push-sample"></a>Step 1: Push the Sample App
 
 Perform the following steps to push a sample application to PCF. 
 
 1. Clone the Apigee Edge GitHub repo:
-    <pre class="terminal">$ git clone <span>https:</span>//github.com/apigee/cloud-foundry-apigee.git</pre>
+
+    ```bash
+    $ git clone <span>https:</span>//github.com/apigee/cloud-foundry-apigee.git
+    ```
 
 1. Change to the `org-and-microgateway-sample` directory of the cloned repo:
-    <pre class="terminal">$ cd cloud-foundry-apigee/samples/org-and-microgateway-sample</pre>
+    
+    ```bash
+    $ cd cloud-foundry-apigee/samples/org-and-microgateway-sample
+    ```
 
 1. In the `org-and-microgateway-sample` directory, open `manifest.yml`.
 
 1. Edit `manifest.yml` to change the `name` and `host` properties to values specific to your deployment. See the following example:
 
-    ```
+    ```yaml
     applications: 
     - name: sample-api 
       memory: 128M 
@@ -43,107 +40,44 @@ Perform the following steps to push a sample application to PCF.
       path: . 
       buildpack: nodejs_buildpack
     ```
+    
 1. Save the edited file.
 
 1. Set your API endpoint to the Cloud Controller of your deployment.
-  <pre class="terminal">
-  $ cf api api.YOUR-SYSTEM-DOMAIN
-  Setting api endpoint to api.YOUR-SYSTEM-DOMAIN...
-  OK
-  API endpoint:  <span>https:</span>//api.YOUR-SYSTEM-DOMAIN (API version: 2.59.0)
-  Not logged in. Use 'cf login' to log in.
-  </pre>
+
+    ```bash
+    $ cf api api.YOUR-SYSTEM-DOMAIN
+    Setting api endpoint to api.YOUR-SYSTEM-DOMAIN...
+    OK
+    API endpoint:  <span>https:</span>//api.YOUR-SYSTEM-DOMAIN (API version: 2.59.0)
+    Not logged in. Use 'cf login' to log in.
+    ```
 
 1. Log in to your deployment and select an org and a space.
-  <pre class="terminal">
-  $ cf login
-  API endpoint: <span>https:</span>//api.YOUR-SYSTEM-DOMAIN
-  Email> user<span>@</span>example.com
-  Password>
-  </pre>
+
+    ```bash
+    $ cf login
+    API endpoint: <span>https:</span>//api.YOUR-SYSTEM-DOMAIN
+    Email> user<span>@</span>example.com
+    Password>
+    ```
 
 1. Push the sample app to PCF:
-    <pre class="terminal">$ cf push YOUR-SAMPLE-APP</pre>
+    
+    ```bash
+    $ cf push YOUR-SAMPLE-APP
+    ```
 
 1. Use `curl` to send a test request to the app you pushed:
-    <pre class="terminal">
+    
+    ```bash
     $ curl YOUR-SAMPLE-APP.YOUR-SYSTEM-DOMAIN
     {"hello":"hello from cf app"} 
-    </pre>
+    ```
+    
     If you receive the above response, the sample app is running successfully.
 
-## <a name="instance"></a>Step 2: Install the Plugin
-
-1. Install the Apigee Broker Plugin as follows.
-    <pre class="terminal">
-    $ cf install-plugin -r CF-Community "apigee-broker-plugin"                                                                                                                                 
-    Searching CF-Community for plugin apigee-broker-plugin...
-    Plugin apigee-broker-plugin 0.1.1 found in: CF-Community
-    Attention: Plugins are binaries written by potentially untrusted authors.
-    Install and use plugins at your own risk.
-    Do you want to install the plugin apigee-broker-plugin? [yN]: y
-    Starting download of plugin binary from repository CF-Community...
-    7.85 MiB / 7.85 MiB [===========================================================================================================================================================================================================================================] 100.00% 11s
-    Installing plugin Apigee-Broker-Plugin...
-    OK
-    Plugin Apigee-Broker-Plugin 0.1.1 successfully installed.
-    </pre>
-
-1. Make sure the plugin is available by running the following command:
-
-    <pre class="terminal">
-    $ cf -h
-    …
-    Commands offered by installed plugins:
-      apigee-bind-mg,abm      apigee-unbind-mgc,auc    enable-diego
-      apigee-bind-mgc,abc     apigee-unbind-org,auo    has-diego-enabled
-      apigee-bind-org,abo     dea-apps                 migrate-apps
-      apigee-push,ap          diego-apps               dev,pcfdev
-      apigee-unbind-mg,aum    disable-diego
-    </pre>
-
-## <a id="create-instance"></a>Step 3: Create a Service Instance
-
-Perform the following steps to create an instance of the Apigee Edge service:
-
-1. List the Marketplace services and locate the Apigee Edge service:
-
-    <pre class="terminal">
-    $ cf marketplace
-    Getting services from marketplace in org example / space development as user<span>@</span>example.com...
-    OK
-
-    service          plans                     description
-    apigee-edge      org, microgateway, microgateway-coresident         Apigee Edge API Platform
-    </pre>
-
-1. Create an instance of the Apigee Edge service. Select the `microgateway` service plan to have Apigee Edge Microgateway run in a separate container from your Cloud Foundry app.
-
-    <pre class="terminal">$ cf create-service apigee-edge microgateway YOUR-SERVICE-INSTANCE -c \
-    '{"org":"YOUR-ORG", "env":"YOUR-ENV"}'</pre>
-
-1. Use the `cf service` command to display information about the service instance:
-
-    <pre class="terminal">
-    $ cf service apigee-service
-
-    Service instance: apigee-service
-    Service: apigee-edge
-    Bound apps:
-    Tags:
-    Plan: microgateway
-    Description: Apigee Edge API Platform
-    Documentation url: http://apigee.com/docs/
-    Dashboard: https://enterprise.apigee.com/platform/#/
-
-    Last Operation
-    Status: create succeeded
-    Message:
-    Started: 2016-10-27T20:47:43Z
-    Updated:
-    </pre>
-
-## <a name="install-microgateway"></a>Step 4: Install Apigee Edge Microgateway and Cloud Foundry App
+## <a name="install-microgateway"></a>Step 2: Install Apigee Edge Microgateway and Cloud Foundry App
 
 Here, you install Apigee Edge Microgateway and your Cloud Foundry app to the same Cloud Foundry container.
 
@@ -152,9 +86,12 @@ Here, you install Apigee Edge Microgateway and your Cloud Foundry app to the sam
 1. Locate and make any desired changes to the configuration YAML file created in your Apigee Edge Microgateway installation, typically in the `.edgemicro` directory.
 
 1. Clone the Apigee Microgateway repository.
-    <pre class="terminal">$ git clone https://github.com/apigee-internal/microgateway.git
+    
+    ```bash
+    $ git clone https://github.com/apigee-internal/microgateway.git
     cd microgateway
-    git checkout tags/v.2.5.4</pre>
+    git checkout tags/v.2.5.4
+    ```
 
 1. Copy the configuration file to the following directory in your Cloud Foundry app: `<application-folder>/<config-directory>`. 
 
@@ -173,105 +110,113 @@ Here, you install Apigee Edge Microgateway and your Cloud Foundry app to the sam
 
 1. Push Apigee Microgateway as its own app.
 
-    <pre class="terminal">cf push</pre>
+    ```bash
+    $ cf push
+    ```
 
-## <a id="bind-app-route"></a>Step 5: Bind the App Route to the Service Instance
+## <a id="bind-app-route"></a>Step 3: Bind the App Route to the Service Instance
 
-In this step, you bind a Cloud Foundry app to the Apigee service instance you 
-created. The `apigee-bind-mg` command creates the proxy for you and binds the app to the service.   
+In this step, you bind a Cloud Foundry app's route (its address in Cloud Foundry) to the Apigee service instance you created. That way, requests to the app will be forwarded first to an Apigee Edge Microgateway proxy. The `bind-route-service` command creates the proxy for you and binds the route to it.
 
-Each bind attempt requires authorization with Apigee Edge, with credentials 
-passed as additional parameters to the `apigee-bind-mg` command. You can pass 
-these credentials as arguments of the `apigee-bind-mg` command or by using a 
-bearer token.
+Each bind attempt requires authorization with Apigee Edge, with credentials passed as additional parameters to the `cf` bind command.
 
-1. If you're using a bearer token to authenticate with Apigee Edge, get or 
-   update the token using the Apigee SSO CLI script. (If you're instead using 
-   command-line arguments to authenticate with username and password, specify 
-   the credentials in the next step.)
-    1. Download the Apigee Edge scripts:
+1. Get or update the authorization token using the Apigee SSO CLI script.
 
-	    <pre class="terminal">$ curl <span>https:</span>//login.apigee.com/resources/scripts/sso-cli/ssocli-bundle.zip -o "ssocli-bundle.zip"</pre>
-	1. Unzip the `ssocli-bundle.zip` file. This includes `get_token`, a script that gets or updates a token that you use to authenticate with your Apigee Edge organization. You need this token to bind the Apigee Edge route service to your app.
+  1. Download the Apigee Edge scripts:
 
-	    <pre class="terminal">$ tar xvf ssocli-bundle.zip</pre>
-	1. Create a `.sso-cli` directory in your user directory:
+      ```bash
+      $ curl https://login.apigee.com/resources/scripts/sso-cli/ssocli-bundle.zip -o "ssocli-bundle.zip"
+      ```
 
-	    <pre class="terminal">$ mkdir ~/.sso-cli</pre>
-	1. Use the `get_token` script to create a token. When prompted, enter the Apigee Edge username and password you use to log in to your organization.
+  1. Unzip the `ssocli-bundle.zip` file. This includes `get_token`, a script that gets or updates a token that you use to authenticate with your Apigee Edge organization. You need this token to bind the Apigee Edge route service to your app.
 
-	    <pre class="terminal">$ ./get\_token</pre>  
-	    The `get_token` script writes the token file into `~/.sso-cli`. For more about `get_token`, see the [Apigee documentation](http://docs.apigee.com/api-services/content/using-oauth2-security-apigee-edge-management-api).
-1. Use the `apigee-bind-mg` command to create an Apigee Edge API proxy and bind your Cloud Foundry app to the proxy. (See the reference on this page for more about this command.)
+      ```bash
+      $ tar xvf ssocli-bundle.zip
+      ```
 
-    You'll need to run the command twice: once to create the proxy, then again to  bind the service to the proxy. The proxy must be loaded by Microgateway instances before binding.
+  1. Create a `.sso-cli` directory in your user directory:
 
-    When you use the command without arguments, you'll be prompted for argument values. To use the command with arguments, see the command reference at the end of this topic. For help on the command, type `cf apigee-bind-mg -h`. Without arguments, you'll be prompted for the following:
+      ```bash
+      $ mkdir ~/.sso-cli
+      ```
 
-    Argument | Description
-    --- | ---
-    Apigee username | Apigee user name. Not used if you pass a bearer token with the `--bearer` argument.
-    Apigee password | Apigee password. Not used if you pass a bearer token with the `--bearer` argument.
-    Action to take | Required. `proxy` to generate an API proxy; `bind` to bind the service with the proxy; `proxy bind` to generate the proxy and bind with a single command.
-    Apigee environment | Required. The Apigee environment where your proxy should be deployed.
-    Apigee organization | Required. The Apigee organization where your proxy should be created.
-    Application to bind to | Required. Name of the the Cloud Foundry application to bind to.
-    Domain to bind to | Required. Domain of the application to bind to.
-    Route of the application acting as microgateway | Required. Route of the application acting as Edge Microgateway.
-    Target application protocol | Optional. The application protocol, such as http or https.
-    Service instance name to bind to | Required. Name of the Apigee service to bind to.
+  1. Use the `get_token` script to create a token. When prompted, enter the Apigee Edge username and password you use to log in to your organization.
 
-	1. First, create the proxy. When prompted for the action to take, enter `proxy`.
+      ```bash
+      $ ./get\_token
+      ```
 
-	    <pre class="terminal">$ cf apigee-bind-mg</pre>
-	
-	    The command creates an API proxy on the specified Apigee org and environment, then binds the Apigee service to the target app. The protocol parameter specifies the protocol through which the proxy's target endpoint will be called. To do its work, this command authenticates with Apigee Edge using the credentials you specified.  
+    The `get_token` script writes the token file into `~/.sso-cli`. For more about `get_token`, see the [Apigee documentation](http://docs.apigee.com/api-services/content/using-oauth2-security-apigee-edge-management-api).
 
-	    Cloud Foundry will report an error because the bind was not attempted. But the message returned should indicate that the proxy was created, which you can check with the Edge management UI or API. The proxies created by the bind for Microgateway have an additional edgemicro_ at the beginning of their name, a general requirement unrelated to Cloud Foundry and service brokers.  
+1. Bind the app's route to the Apigee service instance with the domain and hostname.
 
-	    Wait for the configuration to reload on the Edge Microgateway instance(s) before binding. You might have to wait 5 to 10 minutes. When it has reloaded, the console will list the proxy you just created.
+    The proxy must be created as a separate step, and then loaded by Microgateway instances before binding. You can create the proxy manually, but to have the broker do it, specify "action":"proxy". Also specify the Microgateway's FQDN as micro.
 
-	1. Next, bind the service to the proxy by running the command again. This time, for the action, specify bind for the `action` argument.
+    In this example, Apigee Edge Microgateway is also installed as an app with the hostname edgemicro-app:
 
-	    <pre class="terminal">$ cf apigee-bind-mg</pre>
+    Use the [`bind-route-service`](#bind-route-service-reference) command. The following example creates an API proxy on the `myorg` org and `test` environment. The protocol parameter specifies the protocol through which the proxy will be called. To do its works, this command authenticates with Apigee Edge using the token in the specified .dat file:
 
-	    The proxy is part of a published API Product; a change you must make manually by following the instructions [here](http://docs.apigee.com/microgateway/latest/setting-and-configuring-edge-microgateway#Part2) to create a product with your newly created proxy.
- 
-### apigee-bind-mg Reference
+    ```bash
+    $ cf bind-route-service local.pcfdev.io myapigee --hostname test-app \
+    -c '{"org":"myorg","env":"test",
+       "bearer":"'$(cat ~/.sso-cli/valid_token.dat)'",
+       "micro":"edgemicro-app.local.pcfdev.io",
+       "action":"proxy",
+       "protocol":"http"}'
+    ```
 
-Use the apigee-bind-mg command to generate an API proxy on Apigee Edge and to bind the Cloud Foundry service to the proxy.   
+    Cloud Foundry will report an error during the binding, since the bind was not attempted. But the message returned should indicate that the proxy was created, which you can check with the Edge management UI or API. The proxies created by the bind for Microgateway have an additional edgemicro_ at the beginning of their name, a general requirement unrelated to Cloud Foundry and service brokers.
 
-The command requires your Apigee Edge credentials in order to create and bind to an API proxy. You can specify credentials either with a bearer token or by giving a username and password at the command line. To use a token, you must provide the --bearer argument.
+    Wait for the configuration to reload on the Edge Microgateway instance(s) before binding. You might have to wait 5 to 10 minutes. When it has reloaded, the console will list the proxy you just created.
 
-To be prompted for argument values (and provide a username and password at prompts), use the command without arguments.  
+    To bind, make the same call with "action":"bind"
 
-<pre class="terminal">$ cf apigee-bind-mg</pre>
+    ```bash
+    $ cf bind-route-service local.pcfdev.io myapigee --hostname test-app \
+    -c '{"org":"<your edge org>","env":"<your edge env>",
+       "bearer":"'$(cat ~/.sso-cli/valid_token.dat)'",
+       "micro":"edgemicro-app.local.pcfdev.io",
+       "action":"bind"}'
+    ```
 
-To specify arguments on the command line, use the following syntax (be sure to 
-use quotes and command expansion, as shown here):
+    The proxies created by the bind for Microgateway have an additional `edgemicro_` at the beginning of their name, a general requirement unrelated to Cloud Foundry and service brokers. Another general requirement is that the proxy is part of a published API Product; a change you must make manually by following the instructions [here](http://docs.apigee.com/microgateway/latest/setting-and-configuring-edge-microgateway#Part2) to create a product with your newly created proxy.
+
+## bind-route-service reference
+Use the `bind-route-service` command to generate an API proxy on Apigee Edge and to bind the Apigee Cloud Foundry service to the proxy. The command this form (be sure to use quotes and command expansion, as shown here):
 
 ```bash
-$ cf apigee-bind-mg [--app APP_NAME] [--service SERVICE_INSTANCE] \
-   [--apigee_org APIGEE_ORGANIZATION] [--apigee_env APIGEE_ENVIRONMENT] \
-   [--micro MICROGATEWAY_APP_ROUTE] [--protocol TARGET_APP_PROTOCOL] 
-   [--domain APP_DOMAIN] [--action ACTION] \
-   [--user APIGEE_USERNAME] [--pass APIGEE_PASSWORD] \
-   [--bearer APIGEE_BEARER_TOKEN]
+$ cf bind-route-service <your-app-domain> <service-instance> [--hostname <hostname>] \
+-c '{"org":"<your edge org>","env":"<your edge env>",
+  "bearer":"<authentication-token-file>" | "basic":"<encoded-username-password>" | "<username>:<password>",
+  "micro":"<microgateway_app_route>" 
+  "action":"proxy"|"bind"|"proxy bind",
+  ["protocol":"http"|"https"]}'
 ```
+
+Parameters for the `-c` argument specify connection details:
 
 Parameter | Purpose | Allowed Values
 ---- | ---- | ----
-`action` | Required. A value specifying whether to create or bind an API proxy | `proxy` to generate an API proxy; `bind` to bind the service with the proxy; `proxy bind` to generate the proxy and bind with a single command.
-`apigee_env` | Required. Apigee Edge environment to which the API proxy is (or will be) deployed | Your environment.
-`apigee_org` | Required. Apigee Edge organization hosting the API proxy to be called |  Your organization (must be reachable via the authentication token specified in the `bearer` parameter)
-`app` | Required. Name of the the Cloud Foundry application to bind to. | The app name.
+`org` | Apigee Edge organization hosting the API proxy to be called |  Your organization (must be reachable via the authentication token specified in the `bearer` parameter)
+`env` | Apigee Edge environment to which the API proxy is (or will be) deployed | Your environment.
 `bearer` | Path to a file containing an authentication token valid for your organization | An authentication token, such as one generated with Apigee's get_token command. The broker does not store any data; it requires credentials and other parameters for each individual `cf` command. Instead of a `bearer` token, credentials can also be expressed as:<ul><li>`basic`: standard HTTP Base-64 encoded username and password for `Authorization: Basic`. Note that this is *not encrypted* and easily converted to clear text. But a jumble of digits and letters may provide some protection in case of momentary exposure (but no better than if the password is already a jumble of digits, letters, and symbols)</li><li>username and password in clear text</li></ul>
-`domain` | Required. Domain of the application to bind to. | 
 `micro` | Required. Route of the application acting as Edge Microgateway. | Required.
-`pass` | Apigee password. Not used if you pass a bearer token with the --bearer argument. | Your password.
+`action` | A value specifying whether to create or bind an API proxy | `proxy` to generate an API proxy; `bind` to bind the service with the proxy; `proxy bind` to generate the proxy and bind with a single command.
 `protocol` | The protocol through which the proxy should be accessed by Cloud Foundry | `http` or `https`; default is `https`.
-`service` | Required. Name of the Apigee service to bind to. | The service name.
-`user` | Apigee user name. Not used if you pass a bearer token with the --bearer argument. | Your user name.
+
+## Unbinding the route service
+
+The unbind command does not accept any parameters
+
+```bash
+$ cf unbind-route-service <your-app-domain> <service-instance> --hostname <cf-app>
+```
+
+## Uninstalling the service instance and broker
+```bash
+$ cf delete-service <service-instance>
+$ cf delete-service-broker apigee-edge
+```
 
 ## <a id="test-binding"></a>Step 5: Test the Binding
 

--- a/proxying-org.html.md.erb
+++ b/proxying-org.html.md.erb
@@ -7,116 +7,98 @@ owner: Partners
 
 This topic describes how to push a sample app to Pivotal Cloud Foundry (PCF), create an Apigee Edge service instance, and bind the application to it. After binding the application to the Apigee Edge service instance, requests to the app will be forwarded to an Apigee Edge API proxy for management.
 
-Before performing the procedures in this topic, you must [install and configure](installing.html) the Apigee Edge Service Broker for PCF tile.
-
-> Steps in these instructions use CF CLI with an Apigee plugin. To see corresponding CF CLI commands, see [Mapping for Apigee and Cloud Foundry integration commands](https://github.com/apigee/cloud-foundry-apigee/tree/master/docs/mapping-apigee-cf-cli.md).
+Before performing the procedures in this topic, you must [install and configure](install-and-configure-apigee-service-broker) the Apigee Edge Service Broker for PCF tile.
 
 ## <a id="push-sample"></a>Step 1: Push the Sample App
 
-Perform the following steps to push a sample application to PCF. 
+Perform the following steps to push a sample application to PCF.
 
 1. Clone the Apigee Edge GitHub repo:
-    <pre class="terminal">$ git clone <span>https:</span>//github.com/apigee/cloud-foundry-apigee.git</pre>
+
+    ```bash
+    $ git clone https://github.com/apigee/cloud-foundry-apigee.git
+    ```
 
 1. Change into the `sample-api` directory of the cloned repo:
-    <pre class="terminal">$ cd cloud-foundry-apigee/samples/org-and-microgateway-sample</pre>
+
+    ```bash
+    $ cd cloud-foundry-apigee/samples/org-and-microgateway-sample</pre>
+    ```
 
 1. In the `org-and-microgateway-sample` directory, open `manifest.yml`.
 
 1. Edit `manifest.yml` to change the `name` and `host` properties to values specific to your deployment. See the following example:
 
-    ```
-    applications: 
-    - name: sample-api 
-      memory: 128M 
-      instances: 1 
-      host: sample-api-apigee 
-      path: . 
+    ```yaml
+    applications:
+    - name: sample-api
+      memory: 128M
+      instances: 1
+      host: sample-api-apigee
+      path: .
       buildpack: nodejs_buildpack
     ```
 1. Save the edited file.
 
 1. Set your API endpoint to the Cloud Controller of your deployment.
-  <pre class="terminal">
+
+  ```bash
   $ cf api api.YOUR-SYSTEM-DOMAIN
   Setting api endpoint to api.YOUR-SYSTEM-DOMAIN...
   OK
-  API endpoint:  <span>https:</span>//api.YOUR-SYSTEM-DOMAIN (API version: 2.59.0)
+  API endpoint:  https://api.YOUR-SYSTEM-DOMAIN (API version: 2.59.0)
   Not logged in. Use 'cf login' to log in.
-  </pre>
+  ```
 
 1. Log in to your deployment and select an org and a space.
-  <pre class="terminal">
+
+  ```bash
   $ cf login
-  API endpoint: <span>https:</span>//api.YOUR-SYSTEM-DOMAIN
-  Email> user<span>@</span>example.com
+  API endpoint: https://api.YOUR-SYSTEM-DOMAIN
+  Email> user@example.com
   Password>
-  </pre>
+  ```
 
 1. Push the sample app to PCF:
-    <pre class="terminal">$ cf push YOUR-SAMPLE-APP</pre>
+
+    ```bash
+    $ cf push YOUR-SAMPLE-APP
+    ```
 
 1. Use `curl` to send a test request to the app you pushed:
-    <pre class="terminal">
+
+    ```bash
     $ curl YOUR-SAMPLE-APP.YOUR-SYSTEM-DOMAIN
-    {"hello":"hello from cf app"} 
-    </pre>
+    {"hello":"hello from cf app"}
+    ```
     If you receive the above response, the sample app is running successfully.
 
-## <a name="instance"></a>Step 2: Install the plugin
-
-1. Install the Apigee Broker Plugin as follows.
-    <pre class="terminal">
-    $ cf install-plugin -r CF-Community "apigee-broker-plugin"                                                                                                                                 
-    Searching CF-Community for plugin apigee-broker-plugin...
-    Plugin apigee-broker-plugin 0.1.1 found in: CF-Community
-    Attention: Plugins are binaries written by potentially untrusted authors.
-    Install and use plugins at your own risk.
-    Do you want to install the plugin apigee-broker-plugin? [yN]: y
-    Starting download of plugin binary from repository CF-Community...
-    7.85 MiB / 7.85 MiB [===========================================================================================================================================================================================================================================] 100.00% 11s
-    Installing plugin Apigee-Broker-Plugin...
-    OK
-    Plugin Apigee-Broker-Plugin 0.1.1 successfully installed.
-    </pre>
-
-1. Make sure the plugin is available by running the following command:
-
-    <pre class="terminal">
-    $ cf -h
-    …
-    Commands offered by installed plugins:
-      apigee-bind-mg,abm      apigee-unbind-mgc,auc    enable-diego
-      apigee-bind-mgc,abc     apigee-unbind-org,auo    has-diego-enabled
-      apigee-bind-org,abo     dea-apps                 migrate-apps
-      apigee-push,ap          diego-apps               dev,pcfdev
-      apigee-unbind-mg,aum    disable-diego
-    </pre>
-
-## <a id="create-instance"></a>Step 3: Create a Service Instance
+## <a id="create-instance"></a>Step 2: Create a Service Instance
 
 Perform the following steps to create an instance of the Apigee Edge service:
 
 1. List the Marketplace services and locate the Apigee Edge service:
 
-    <pre class="terminal">
+    ```bash
     $ cf marketplace
-    Getting services from marketplace in org example / space development as user<span>@</span>example.com...
+    Getting services from marketplace in org example / space development as user@example.com...
     OK
 
     service          plans                                              description
     apigee-edge      org, microgateway, microgateway-coresident         Apigee Edge API Platform
-    </pre>
+    ```
 
 1. Create an instance of the Apigee Edge service. Select either the `org` service plan.
 
-    <pre class="terminal">$ cf create-service apigee-edge org YOUR-SERVICE-INSTANCE -c \
+    ```bash
+    $ cf create-service apigee-edge org YOUR-SERVICE-INSTANCE -c \
     '{"org":"YOUR-ORG", "env":"YOUR-ENV"}'
-cf service YOUR-SERVICE-INSTANCE</pre>
+    cf service YOUR-SERVICE-INSTANCE
+    ```
 
 1. Use the `cf service` command to display information about the service instance:
 
-    <pre class="terminal">
+    ```bash
     $ cf service apigee-service
 
     Service instance: apigee-service
@@ -133,91 +115,96 @@ cf service YOUR-SERVICE-INSTANCE</pre>
     Message:
     Started: 2016-10-27T20:47:43Z
     Updated:
-    </pre>
+    ```
 
-## <a id="bind-app-route"></a>Step 4: Bind the App Route to the Service Instance
+## <a id="bind-app-route"></a>Step 3: Bind the App Route to the Service Instance
 
+In this step, you bind a Cloud Foundry app's route (its address in Cloud Foundry) to the Apigee service instance you created. That way, requests to the app will be forwarded first to an Edge proxy. The `bind-route-service` command creates the proxy for you and binds the route to it.
 
-Perform the following steps to bind the route of your app to your Apigee Edge service instance.
+Each bind attempt requires authorization with Edge, passed as additional parameters to the `cf` bind command.
 
-Each bind attempt requires authorization with Apigee Edge, with credentials 
-passed as additional parameters to the `apigee-bind-org` command. You can pass 
-these credentials as arguments of the `apigee-bind-org` command or by using a 
-bearer token.
+1. Get or update the token using the Apigee SSO CLI script.
 
-1. If you're using a bearer token to authenticate with Apigee Edge, get or 
-   update the token using the Apigee SSO CLI script.    (If you're instead using command-line arguments to authenticate with username and password, specify the credentials in the next step.)
-   
     1. Download the Apigee Edge scripts:
-   
-        <pre class="terminal">$ curl <span>https:</span>//login.apigee.com/resources/scripts/sso-cli/ssocli-bundle.zip -o "ssocli-bundle.zip"</pre>
+
+        ```bash
+        $ curl https://login.apigee.com/resources/scripts/sso-cli/ssocli-bundle.zip -o "ssocli-bundle.zip"
+        ```
     1. Unzip the `ssocli-bundle.zip` file. This includes `get_token`, a script that gets or updates a token that you use to authenticate with your Apigee Edge organization. You need this token to bind the Apigee Edge route service to your app.
 
-        <pre class="terminal">$ tar xvf ssocli-bundle.zip</pre>
+        ```bash
+        $ tar xvf ssocli-bundle.zip
+        ```
     1. Create a `.sso-cli` directory in your user directory:
-	
-        <pre class="terminal">$ mkdir ~/.sso-cli</pre>
+
+        ```bash
+        $ mkdir ~/.sso-cli
+        ```
     1. Use the `get_token` script to create a token. When prompted, enter the Apigee Edge username and password you use to log in to your organization.
-	
-        <pre class="terminal">$ ./get\_token</pre>  
-       The `get_token` script writes the token file into `~/.sso-cli`. For more about `get_token`, see the [Apigee documentation](https://docs.apigee.com/api-platform/system-administration/using-oauth2).
 
-        > You may be prompted for your Apigee Edge username and password, and an MFA token. This updates the token in the ~/.sso-cli/valid\_token.dat file (if that subdirectory exists – otherwise the file is placed in the current working directory). The next step uses this token.
+        ```bash
+        $ ./get\_token
+        ```
+       The `get_token` script writes the token file into `~/.sso-cli`. For more about `get_token`, see the [Apigee documentation](/api-platform/system-administration/using-oauth2).
 
-1. Bind the app to the Apigee service instance with the `apigee-bind-org` command.
+        > You may be prompted for your Apigee Edge username and password, and an MFA token. This updates the token in the ~/.sso-cli/valid\_token.dat file (if that subdirectory exists – otherwise the file is placed in the current working directory).
 
-    When you use the command without arguments, you'll be prompted for argument values. To use the command with arguments, see the command reference at the end of this topic. For help on the command, type `cf apigee-bind-org -h`. Without arguments, you'll be prompted for the following:
+1. Bind the app's route to the Apigee service instance with the domain and hostname.
 
-    Argument | Description
-    --- | ---
-    Apigee username | Apigee user name. Not used if you pass a bearer token with the `--bearer` argument.
-    Apigee password | Apigee password. Not used if you pass a bearer token with the `--bearer` argument.
-    Action to take | Required. `proxy` to generate an API proxy; `bind` to bind the service with the proxy; `proxy bind` to generate the proxy and bind with a single command.
-    Apigee environment | Required. The Apigee environment where your proxy should be deployed.
-    Apigee organization | Required. The Apigee organization where your proxy should be created.
-    Application to bind to | Required. Name of the the Cloud Foundry application to bind to.
-    Domain to bind to | Required. Domain of the application to bind to.
-    Route of the application acting as microgateway | Required. Route of the application acting as Edge Microgateway.
-	Host | The host domain to which API calls are made. Specify a value only if your host domain is not the same as that given by your virtual host.
-    Target application protocol | The application protocol, such as http or https.
-    Service instance name to bind to | Required. Name of the Apigee service to bind to.
+    Use the [`bind-route-service`](#bind-route-service-reference) command. The following example does two things: it creates an API proxy on the `myorg` org and `test` environment, then binds the Apigee route service to the proxy. The protocol parameter specifies the protocol through which the proxy will be called. To do its works, this command authenticates with Apigee Edge using the token in the specified .dat file:
 
-### apigee-bind-org reference
+    ```bash
+    $ cf bind-route-service local.pcfdev.io myapigee --hostname test-app \
+    -c '{"org":"myorg","env":"test",
+      "bearer":"'$(cat ~/.sso-cli/valid_token.dat)'",
+      "action":"proxy bind",
+      "protocol":"https"}'
+    ```
 
-Use the `apigee-bind-org` command to generate an API proxy on Apigee Edge and to bind the Cloud Foundry service to the proxy.
+1. Log into Edge and note that the proxy has been created, and that requests to your app are being routed through Edge.
 
-The command requires your Apigee Edge credentials in order to create and bind to an API proxy. You can specify credentials either with a bearer token or by 
-giving a username and password at the command line. To use a token, you must 
-provide the `--bearer` argument. To be prompted for argument values (and provide a username and password at prompts), use the command without arguments. 
+    You will find a proxy whose name matches the pattern specified by the APIGEE_PROXY_NAME_TEMPLATE variable you specified with your org and env mapping in the manifest. The proxy has been deployed to the environment you specified when you created your service instance.
 
+    In the Edge management console, begin tracing the proxy, then send requests to your app. Trace will show the traffic routing through the proxy.
+
+    You can now configure standard Apigee Edge policies on that proxy.
+
+### bind-route-service reference
+Use the `bind-route-service` command to generate an API proxy on Apigee Edge and to bind the Apigee Cloud Foundry service to the proxy. The command this form (be sure to use quotes and command expansion, as shown here):
+
+```bash
+$ cf bind-route-service <your-app-domain> <service-instance> [--hostname <hostname>] \
+-c '{"org":"<your edge org>","env":"<your edge env>",
+  "bearer":"'<authentication-token-file>'" | "basic":"<encoded-username-password>" | "<username>:<password>",
+  "action":"proxy"|"bind"|"proxy bind",
+  ["protocol":"http"|"https"]}'
 ```
-cf apigee-bind-org
-```
 
-To specify arguments on the command line, use the following syntax (be sure to 
-use quotes and command expansion, as shown here):
-
-<pre class="terminal">
-$ cf apigee-bind-org [--app APP_NAME] [--service SERVICE_INSTANCE] \
-    [--apigee_org APIGEE_ORGANIZATION] [--apigee_env APIGEE_ENVIRONMENT] \ 
-    [--protocol TARGET_APP_PROTOCOL] [--domain APP_DOMAIN] [--action ACTION] \
-    [--user APIGEE_USERNAME] [--pass APIGEE_PASSWORD] \
-    [--bearer APIGEE_BEARER_TOKEN] [--host HOST_NAME]
-</pre>
+Parameters for the `-c` argument specify connection details:
 
 Parameter | Purpose | Allowed Values
 ---- | ---- | ----
-`action` | Required. A value specifying whether to create or bind an API proxy | `proxy` to generate an API proxy; `bind` to bind the service with the proxy; `proxy bind` to generate the proxy and bind with a single command.
-`apigee_env` | Required. Apigee Edge environment to which the API proxy is (or will be) deployed | Your environment.
-`apigee_org` | Required. Apigee Edge organization hosting the API proxy to be called |  Your organization (must be reachable via the authentication token specified in the `bearer` parameter)
-`app` | Required. Name of the the Cloud Foundry application to bind to. | The app name.
+`org` | Apigee Edge organization hosting the API proxy to be called |  Your organization (must be reachable via the authentication token specified in the `bearer` parameter)
+`env` | Apigee Edge environment to which the API proxy is (or will be) deployed | Your environment.
 `bearer` | Path to a file containing an authentication token valid for your organization | An authentication token, such as one generated with Apigee's get_token command. The broker does not store any data; it requires credentials and other parameters for each individual `cf` command. Instead of a `bearer` token, credentials can also be expressed as:<ul><li>`basic`: standard HTTP Base-64 encoded username and password for `Authorization: Basic`. Note that this is *not encrypted* and easily converted to clear text. But a jumble of digits and letters may provide some protection in case of momentary exposure (but no better than if the password is already a jumble of digits, letters, and symbols)</li><li>username and password in clear text</li></ul>
-`domain` | Required. Domain of the application to bind to. | 
-`host` | The host domain to which API calls are made. Specify a value only if your host domain is not the same as that given by your virtual host. | Your host domain name if different from your virtual host domain. For example: mycompany.net:9000
-`pass` | Apigee password. Not used if you pass a bearer token with the --bearer argument. | Your password.
+`action` | A value specifying whether to create or bind an API proxy | `proxy` to generate an API proxy; `bind` to bind the service with the proxy; `proxy bind` to generate the proxy and bind with a single command.
 `protocol` | The protocol through which the proxy should be accessed by Cloud Foundry | `http` or `https`; default is `https`.
-`service` | Required. Name of the Apigee service to bind to. | The service name.
-`user` | Apigee user name. Not used if you pass a bearer token with the --bearer argument. | Your user name.
+`host` | The host domain to which API calls are made. Specify a value only if your host domain is not the same as that given by your virtual host. | Your host domain name if different from your virtual host domain. For example: mycompany.net:9000
+
+## Unbinding the route service
+
+The unbind command does not accept any parameters
+
+```bash
+$ cf unbind-route-service <your-app-domain> <service-instance> --hostname <cf-app>
+```
+
+## Uninstalling the service instance and broker
+
+```bash
+$ cf delete-service <service-instance>
+$ cf delete-service-broker apigee-edge
+```
 
 ## <a id="test-binding"></a>Step 5: Test the Binding
 
@@ -228,13 +215,14 @@ Once you've bound your app's path to the Apigee service (creating an Apigee prox
 1. Click the new proxy's name to view its **Overview** page.
 1. Click the **Trace** tab, then click the **Start Trace Session** button.
 1. Back at the command line, run the `curl` command you ran earlier to make a request to your Cloud Foundry app you pushed, such as:
-  <pre class="terminal">
-  $ curl <span>https:</span>//sample-api-apigee.cfapps.pivotal.io 
-  {"hello":"hello from cf app"} 
-  </pre>
+
+  ```bash
+  $ curl https://sample-api-apigee.cfapps.pivotal.io
+  {"hello":"hello from cf app"}
+  ```
+
   As before, the console outputs the app's response.
 
 1. Return to the Apigee Edge management console to see that your request has now been routed through the Edge proxy you created.
-
 
 The new proxy is just a pass-through, but it is now ready for you or someone on your team to add policies to define security, traffic management, and more.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -3,6 +3,15 @@ title: Release Notes for Apigee Edge Service Broker for PCF
 owner: Partners
 ---
 
+### Version 3.1.1
+
+**Release Date:** September 24, 2018
+
+Features included in this release:
+
+* The [microgatway-coresident](proxying-microgateway-coresident) plan now uses the supply buildpack and support customer Microgateway and Node.js versions and installation options.
+* Returns support of standard Cloud Foundry tooling for binding route services.
+
 ### Version 3.1.0
 
 **Release Date:** June 28, 2018


### PR DESCRIPTION
Updates to content to 
- restore support for standard CF tools
- have microgateway_coresident plan leverage the supply buildpack and support custom MG/Nodejs versions and installation options